### PR TITLE
Move prerequisites to plugin module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,6 @@
     </scm>
 
     <packaging>pom</packaging>
-    <prerequisites>
-        <maven>3.0.4</maven>
-    </prerequisites>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ts-constants-generator-maven/pom.xml
+++ b/ts-constants-generator-maven/pom.xml
@@ -10,6 +10,10 @@
         <version>0.0.4</version>
     </parent>
 
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
+
     <artifactId>ts-constants-generator-maven</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Typescript constants generator maven plugin</name>


### PR DESCRIPTION
Avoid:
```
[WARNING] The project dev.mtomczyk:ts-constants-generator:pom:0.0.4 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```